### PR TITLE
Addition for training lab 5.

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -54,6 +54,8 @@ namespace swss {
 #define APP_NAPT_POOL_IP_TABLE_NAME     "NAPT_POOL_IP_TABLE"
 #define APP_NAT_DNAT_POOL_TABLE_NAME    "NAT_DNAT_POOL_TABLE"
 
+#define APP_TX_ERR_TABLE_NAME           "TX_ERR_APPL"
+
 /***** TO BE REMOVED *****/
 
 #define APP_TC_TO_QUEUE_MAP_TABLE_NAME  "TC_TO_QUEUE_MAP_TABLE"
@@ -226,6 +228,8 @@ namespace swss {
 #define CFG_NAT_BINDINGS_TABLE_NAME                 "NAT_BINDINGS"
 #define CFG_NAT_GLOBAL_TABLE_NAME                   "NAT_GLOBAL"
 
+#define CFG_PORT_TX_ERR_TABLE_NAME                  "TX_ERR_CFG"
+
 /***** STATE DATABASE *****/
 
 #define STATE_SWITCH_CAPABILITY_TABLE_NAME          "SWITCH_CAPABILITY_TABLE"
@@ -246,6 +250,7 @@ namespace swss {
 #define STATE_BGP_TABLE_NAME                        "BGP_STATE_TABLE"
 #define STATE_DEBUG_COUNTER_CAPABILITIES_NAME       "DEBUG_COUNTER_CAPABILITIES"
 #define STATE_NAT_RESTORE_TABLE_NAME                "NAT_RESTORE_TABLE"
+#define STATE_TX_ERR_TABLE_NAME                     "TX_ERR_STATE_TABLE"
 
 /***** MISC *****/
 


### PR DESCRIPTION
Signed-off-by: Raphael Tryster <raphaelt@nvidia.com>

What I did

Implemented a solution for Lab 5 in SONiC training based on one of the solutions provided in the Wiki, with some changes. These include using the counters DB instead of calls to SAI to retrieve the tx error counter, passing the statistics data by reference so that the difference between successive counter readings would be used correctly, and added python code to handle some not found conditions.

Why I did it

I used a prepared solution, studied it with gdb and modified it based on what I observed in gdb, because so much of the way code is written in C++ is unfamiliar that I expected writing from scratch would take an order of magnitude more than the time allotted, and I would get more benefit from studying and modifying existing code.

How I verified it

Configure polling period, e.g.

sudo config tx_error_stat_poll_period 30

Configure error threshold, e.g.

sudo config interface tx_error_threshold set Ethernet0 10

Disable automatic refresh of counters, so that counter values can be injected into DB and stay there:

counterpoll port disable

Lookup OID of port being tested, e.g.

redis-cli -n 2 hgetall "COUNTERS_PORT_NAME_MAP" | grep -A1 "Ethernet0"
Ethernet0
oid:0x10000000008d4

Inject tx errors to that port and verify that DB was updated:

redis-cli -n 2 hset "COUNTERS:oid:0x10000000008d4" "SAI_PORT_STAT_IF_OUT_ERRORS" "20"
(integer) 0
redis-cli -n 2 hget "COUNTERS:oid:0x10000000008d4" "SAI_PORT_STAT_IF_OUT_ERRORS"
"20"

Show status within the poll period:

show interfaces tx_error
Port status statistics

Ethernet0 error 20

Show status after the poll period:

show interfaces tx_error
Port status statistics

Ethernet0 ok 20

Repeat sequences of the above commands to verify that status becomes error when the delta exceeds the threshold, and ok when it doesn't.

Details if related